### PR TITLE
feat: add endpoint to fetch public transport information

### DIFF
--- a/src/api/controllers/info_controller.js
+++ b/src/api/controllers/info_controller.js
@@ -6,7 +6,18 @@ import {
   getBoardgamesFromDatabase,
   getItemCategoriesFromDatabase,
   getGameCategoriesFromDatabase,
+  fetchPublicTransport,
 } from '../models/info_model.js';
+
+const getPublicTransport = async (req, res) => {
+  try {
+    const publicTransport = await fetchPublicTransport();
+    res.status(200).json(publicTransport);
+    // eslint-disable-next-line no-unused-vars
+  } catch (error) {
+    res.status(500).json({error: 'Internal server error'});
+  }
+};
 
 /* eslint-disable no-unused-vars */
 const getMenu = async (req, res) => {
@@ -80,4 +91,5 @@ export {
   getBoardgames,
   getItemCategories,
   getGameCategories,
+  getPublicTransport,
 };

--- a/src/api/rest/info.rest
+++ b/src/api/rest/info.rest
@@ -19,3 +19,5 @@ GET http://localhost:3000/api/v1/info/itemcategories/fi
 ### Fetch game category info
 GET http://localhost:3000/api/v1/info/gamecategories/fi
 
+### Fetch public translation info
+GET http://localhost:3000/api/v1/info/getPublicTransport

--- a/src/api/routes/info_router.js
+++ b/src/api/routes/info_router.js
@@ -7,6 +7,7 @@ import {
   getBoardgames,
   getGameCategories,
   getItemCategories,
+  getPublicTransport,
 } from '../controllers/info_controller.js';
 
 const infoRouter = express.Router();
@@ -24,5 +25,7 @@ infoRouter.route('/boardgames/:lang').get(getBoardgames);
 infoRouter.route('/itemcategories/:lang').get(getItemCategories);
 
 infoRouter.route('/gamecategories/:lang').get(getGameCategories);
+
+infoRouter.route('/getPublicTransport').get(getPublicTransport);
 
 export default infoRouter;


### PR DESCRIPTION
This pull request introduces a new feature to fetch and serve public transport data, including nearby vehicle rentals and stops, through the API. The changes span multiple files to implement the functionality, integrate it into the routing system, and document the new endpoint.

### New Feature: Fetch and Serve Public Transport Data

* **Controller Update**:
  - Added a new `getPublicTransport` controller method in `src/api/controllers/info_controller.js` to handle requests for public transport data. It fetches the data using the `fetchPublicTransport` model function and returns it as a JSON response. [[1]](diffhunk://#diff-6b9362a5cdeefc51f88fae91e33d59b55458d2da00810c3414a149d5e0b10f46R9-R21) [[2]](diffhunk://#diff-6b9362a5cdeefc51f88fae91e33d59b55458d2da00810c3414a149d5e0b10f46R94)

* **Model Update**:
  - Implemented the `fetchPublicTransport` function in `src/api/models/info_model.js`. This function queries the Digitransit API to retrieve nearby vehicle rentals and stops based on restaurant coordinates. It combines the results into a unified response. [[1]](diffhunk://#diff-1ac7a6f644f71f17fda7b271e68cad0de4ce31b783f89d1ee44cc1b6c71db3faR163-R268) [[2]](diffhunk://#diff-1ac7a6f644f71f17fda7b271e68cad0de4ce31b783f89d1ee44cc1b6c71db3faR277)

* **Routing Update**:
  - Added a new route `/getPublicTransport` in `src/api/routes/info_router.js` to map to the `getPublicTransport` controller method. [[1]](diffhunk://#diff-60d1c4cd641508dd9aa1241147d8882d24de4881d23632eda525e738c35a5c7fR10) [[2]](diffhunk://#diff-60d1c4cd641508dd9aa1241147d8882d24de4881d23632eda525e738c35a5c7fR29-R30)

* **Documentation Update**:
  - Documented the new `/getPublicTransport` endpoint in `src/api/rest/info.rest` for testing and reference.