### PR TITLE
feat: include message text in response after posting a message

### DIFF
--- a/src/api/controllers/forum_controller.js
+++ b/src/api/controllers/forum_controller.js
@@ -35,7 +35,7 @@ export const postMessage = async (req, res) => {
       return;
     }
   }
-  res.status(201).json({message: 'Message posted successfully'});
+  res.status(201).json({message: 'Message posted successfully', txt: message});
 };
 
 export default {getAllMessages, postMessage};

--- a/src/api/rest/forum.rest
+++ b/src/api/rest/forum.rest
@@ -2,8 +2,8 @@
 GET http://localhost:3000/api/v1/forum
 
 ### Create a post
-POST http://localhost:3000/api/v1/forum/post/janedoe
-Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwidXNlcm5hbWUiOiJqYW5lZG9lIiwidXNlcl90eXBlIjoiY3VzdG9tZXIiLCJpYXQiOjE3NDY0MjU3NDAsImV4cCI6MTc0NjUxMjE0MH0.dPx_v4TUKJqnGzwYdBTklyp_WmKH9iWYtJKHvv9UrAw
+POST http://localhost:3000/api/v1/forum/post/admin
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MjMsInVzZXJuYW1lIjoiYWRtaW4iLCJ1c2VyX3R5cGUiOiJhZG1pbiIsImlhdCI6MTc0NjUyNDQ3NSwiZXhwIjoxNzQ2NjEwODc1fQ.H36QdQKf7bNCAe72meZFnrMdEby-X6sOIogrlU0SqDc
 Content-Type: application/json
 
 {
@@ -12,8 +12,8 @@ Content-Type: application/json
 }
 
 ### Reply to a post
-POST http://localhost:3000/api/v1/forum/post/9/janedoe
-Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MSwidXNlcm5hbWUiOiJqYW5lZG9lIiwidXNlcl90eXBlIjoiY3VzdG9tZXIiLCJpYXQiOjE3NDY0MjU3NDAsImV4cCI6MTc0NjUxMjE0MH0.dPx_v4TUKJqnGzwYdBTklyp_WmKH9iWYtJKHvv9UrAw
+POST http://localhost:3000/api/v1/forum/post/9/admin
+Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MjMsInVzZXJuYW1lIjoiYWRtaW4iLCJ1c2VyX3R5cGUiOiJhZG1pbiIsImlhdCI6MTc0NjUyNDQ3NSwiZXhwIjoxNzQ2NjEwODc1fQ.H36QdQKf7bNCAe72meZFnrMdEby-X6sOIogrlU0SqDc
 Content-Type: application/json
 
 {


### PR DESCRIPTION
This pull request includes updates to the `forum_controller.js` and `forum.rest` files to enhance the API responses and modify the example user credentials in the API documentation. The most important changes include adding the posted message content to the API response and updating the example API requests to use an admin user's credentials instead of a generic user.

### Enhancements to API responses:
* [`src/api/controllers/forum_controller.js`](diffhunk://#diff-7041240fee93b3223c37586cf13dc158de524bb38a4491ca3b07a2d87a87ce21L38-R38): Updated the `postMessage` function to include the posted message content (`txt`) in the response JSON, providing more detailed feedback to the client.

### Updates to API documentation:
* [`src/api/rest/forum.rest`](diffhunk://#diff-42b3b3446e70a33e0b17d565b99e5f127a8a637373e0078f131437fdb8e63bccL5-R6): Changed the example user credentials in the "Create a post" and "Reply to a post" sections to use an admin user (`admin`) instead of a generic user (`janedoe`). This includes updating the bearer token and user details in the request examples. [[1]](diffhunk://#diff-42b3b3446e70a33e0b17d565b99e5f127a8a637373e0078f131437fdb8e63bccL5-R6) [[2]](diffhunk://#diff-42b3b3446e70a33e0b17d565b99e5f127a8a637373e0078f131437fdb8e63bccL15-R16)