### PR TITLE
feat: enhance message insertion to return full message details after posting

### DIFF
--- a/src/api/controllers/forum_controller.js
+++ b/src/api/controllers/forum_controller.js
@@ -17,25 +17,24 @@ export const postMessage = async (req, res) => {
     return;
   }
 
+  let result = null;
   if (!req.params.to_id) {
-    const result = await insertMessage(message, title, req.user.id, null);
-    if (result.affectedRows === 0) {
+    result = await insertMessage(message, title, req.user.id, null);
+    if (result.result.affectedRows === 0) {
       res.status(500).json({message: 'Failed to post message'});
       return;
     }
   } else {
-    const result = await insertMessage(
-      message,
-      title,
-      req.user.id,
-      req.params.to_id
-    );
-    if (result.affectedRows === 0) {
+    result = await insertMessage(message, title, req.user.id, req.params.to_id);
+    if (result.result.affectedRows === 0) {
       res.status(500).json({message: 'Failed to post reply'});
       return;
     }
   }
-  res.status(201).json({message: 'Message posted successfully', txt: message});
+  res.status(201).json({
+    message: 'Message posted successfully',
+    result: result.message,
+  });
 };
 
 export default {getAllMessages, postMessage};

--- a/src/api/models/forum_model.js
+++ b/src/api/models/forum_model.js
@@ -22,7 +22,7 @@ const listForumPosts = async () => {
   );
 
   // Create a deep copy of rows
-  let result = rows.map((row) => ({ ...row }));
+  let result = rows.map((row) => ({...row}));
 
   for (const row of result) {
     // Fetch the message text for each child message
@@ -65,7 +65,21 @@ const insertMessage = async (message, title, user_id, to_id) => {
     [user_id, result.insertId, to_id]
   );
 
-  return result;
+  const [insertedMessage] = await promisePool.query(
+    'SELECT * FROM message WHERE id = ?',
+    [result.insertId]
+  );
+
+  const [insertedMessageTable] = await promisePool.query(
+    'SELECT * FROM message_table WHERE message_id = ?',
+    [result.insertId]
+  );
+  insertedMessage[0].toMessage = insertedMessageTable[0].to_message_id;
+
+  return {
+    result: result,
+    message: insertedMessage[0],
+  };
 };
 
-export { listForumPosts, insertMessage };
+export {listForumPosts, insertMessage};


### PR DESCRIPTION
This pull request refactors the `postMessage` function in `forum_controller.js` and the `insertMessage` function in `forum_model.js` to improve the handling and structure of database query results. The changes ensure that more detailed information about the inserted message is returned and included in the API response.

### Changes in `forum_controller.js`:

* Refactored `postMessage` to handle the new structure of the `insertMessage` return value, which now includes both the result of the database operation and the inserted message details.
* Updated the success response to include the inserted message details (`result.message`) in addition to the success message.

### Changes in `forum_model.js`:

* Modified `insertMessage` to perform additional queries after inserting a message:
  - Fetches the full details of the inserted message from the `message` table.
  - Retrieves related information from the `message_table` and links it to the inserted message.
  - Returns a structured object containing both the database operation result and the enriched message details.