### PR TITLE
feat: increase maxDistance for public transport queries from 200 to 300

### DIFF
--- a/src/api/models/forum_model.js
+++ b/src/api/models/forum_model.js
@@ -75,6 +75,7 @@ const insertMessage = async (message, title, user_id, to_id) => {
     [result.insertId]
   );
   insertedMessage[0].toMessage = insertedMessageTable[0].to_message_id;
+  insertedMessage[0].messageTableId = insertedMessageTable[0].id;
 
   return {
     result: result,

--- a/src/api/models/info_model.js
+++ b/src/api/models/info_model.js
@@ -186,7 +186,7 @@ const fetchPublicTransport = async () => {
             nearest(
               lat: ${lat},
               lon: ${lon},
-              maxDistance: 200,
+              maxDistance: 300,
               filterByPlaceTypes: [VEHICLE_RENT]
             ) {
               edges {
@@ -230,7 +230,7 @@ const fetchPublicTransport = async () => {
             nearest(
               lat: ${lat},
               lon: ${lon},
-              maxDistance: 200,
+              maxDistance: 300,
               filterByPlaceTypes: [STOP, STATION, CAR_PARK, BIKE_PARK]
             ) {
               edges {


### PR DESCRIPTION
This pull request makes a minor adjustment to the `fetchPublicTransport` function in `src/api/models/info_model.js` by increasing the `maxDistance` parameter from 200 to 300 for two different queries. This change likely aims to broaden the search radius for nearby public transport options.

Details of the changes:

* Increased the `maxDistance` parameter from 200 to 300 in the query filtering by `VEHICLE_RENT` place types.
* Increased the `maxDistance` parameter from 200 to 300 in the query filtering by `STOP`, `STATION`, `CAR_PARK`, and `BIKE_PARK` place types.